### PR TITLE
hide error message on location search or map click

### DIFF
--- a/app/app/public/js/esriMap.js
+++ b/app/app/public/js/esriMap.js
@@ -25,6 +25,8 @@ define([
 
     view.on("click", function(evt) {
       view.graphics.removeAll();
+      // hide error message
+      document.getElementById("errorMessage").style.display = "none";
       // hide results container
       document.getElementById("eContainer").style.display = "none";
       // hide location search error message

--- a/app/app/public/js/script.js
+++ b/app/app/public/js/script.js
@@ -42,6 +42,8 @@ define(["app/esriMap"], function(esriMap) {
     });
 
     function getCoords(_callback) {
+      // hide error message
+      document.getElementById("errorMessage").style.display = "none";
       // hide results container
       document.getElementById("eContainer").style.display = "none";
       // hide location search error message


### PR DESCRIPTION
When the user doesn't search a location before clicking the "Calculate" button, there is a message displayed informing them to search or click a location.

That message is now removed after searching or clicking the map.