### PR TITLE
bugfix/api-docs-301-redirect

### DIFF
--- a/app/app/public/api_key_signup.html
+++ b/app/app/public/api_key_signup.html
@@ -128,7 +128,7 @@
 
 		<div id="apidatagov_signup">Loading signup form...</div>
 		<script type="text/javascript">
-			var smartURL2 = window.location.protocol + "//" + window.location.host + "/api-docs";
+			var smartURL2 = window.location.protocol + "//" + window.location.host + "/api-docs/index.html";
 			/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 			var apiUmbrellaSignupOptions = {
 				registrationSource: 'epa-lew',

--- a/app/app/public/api_key_signup.html
+++ b/app/app/public/api_key_signup.html
@@ -128,7 +128,7 @@
 
 		<div id="apidatagov_signup">Loading signup form...</div>
 		<script type="text/javascript">
-			var smartURL2 = window.location.protocol + "//" + window.location.host + "/api-docs/index.html";
+			var smartURL2 = window.location.protocol + "//" + window.location.host + "/api-docs/";
 			/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 			var apiUmbrellaSignupOptions = {
 				registrationSource: 'epa-lew',

--- a/app/app/public/index.html
+++ b/app/app/public/index.html
@@ -267,7 +267,7 @@
 
                   <p>
                     The R-factor calculation can also be integrated directly into custom applications using the <a
-                      target="_blank" rel="noopener noreferrer" href="/api-docs">R-Factor web service</a>.
+                      target="_blank" rel="noopener noreferrer" href="/api-docs/index.html">R-Factor web service</a>.
                   </p>
 
                   <p>
@@ -540,7 +540,7 @@
     };
   </script>
 
-  <script src="https://js.arcgis.com/4.17/"></script>
+  <script type="text/javascript" charset="utf-8"src="https://js.arcgis.com/4.17/"></script>
 
   <script>
     require(["app/script"], function (script) {

--- a/app/app/public/index.html
+++ b/app/app/public/index.html
@@ -267,7 +267,7 @@
 
                   <p>
                     The R-factor calculation can also be integrated directly into custom applications using the <a
-                      target="_blank" rel="noopener noreferrer" href="/api-docs/index.html">R-Factor web service</a>.
+                      target="_blank" rel="noopener noreferrer" href="/api-docs/">R-Factor web service</a>.
                   </p>
 
                   <p>

--- a/app/app/public/index.html
+++ b/app/app/public/index.html
@@ -540,7 +540,7 @@
     };
   </script>
 
-  <script type="text/javascript" charset="utf-8"src="https://js.arcgis.com/4.17/"></script>
+  <script src="https://js.arcgis.com/4.17/"></script>
 
   <script>
     require(["app/script"], function (script) {


### PR DESCRIPTION
## Related Issues:
* Closes #53 

## Main Changes:
* Fixed an issue with the `api-docs` page returning a `301 moved permanently` status.

## Steps To Test:
1. In Chrome, turn on the "Auto-open DevTools for popups" setting
    * Open Chrome Dev Tools
    * With the dev tools focused, press F1 
    * Click the "Auto-open DevTools for popups" setting (towards the bottom under Global)
2. Navigate to http://localhost:9091/
3. Click on the `R-Factor web service` link
    * This will open a new tab with the dev tools automatically opened
4. Click on the network tab
5. Verify the first request (http://localhost:9091/api-docs/) returns a 200 status code

