### PR TITLE
feature/update-unit-tests-to-mock-response

### DIFF
--- a/app/app/tests/routes/rfactor.test.js
+++ b/app/app/tests/routes/rfactor.test.js
@@ -8,6 +8,9 @@ var chai = require("chai");
 
 const rfactorContoller = require("../../server/controllers/rfactor");
 
+const colostateDomain = 'http://csip.engr.colostate.edu:8088';
+const r2climate = '/csip-misc/d/r2climate/2.0';
+
 describe("rFactor controller testing", () => {
   /****************************************************
    *
@@ -491,8 +494,8 @@ describe("rFactor controller testing", () => {
    *
    ****************************************************/
   it("Climate information not available for location to calculate rFactor test", function(done) {
-    nock('http://csip.engr.colostate.edu:8088')
-      .post('/csip-misc/d/r2climate/2.0').reply(200, {
+    nock(colostateDomain)
+      .post(r2climate).reply(200, {
         metainfo: {},
         parameter: [],
         // leave result off to simulate no results
@@ -532,8 +535,8 @@ describe("rFactor controller testing", () => {
    *
    ****************************************************/
   it("Error retreiving county URL", function(done) {
-    nock('http://csip.engr.colostate.edu:8088')
-      .post('/csip-misc/d/r2climate/2.0').reply(500, {
+    nock(colostateDomain)
+      .post(r2climate).reply(500, {
         metainfo: {},
         parameter: [],
         // leave result off to simulate no results
@@ -548,7 +551,7 @@ describe("rFactor controller testing", () => {
       query: {
         start_date: "2019-02-21",
         end_date: "2019-02-28",
-        location: '{"geometry":{"type":"Point","coordinates":[-14.062500,48.224673]}}',
+        location: '{"geometry":{"type":"Point","coordinates":[-76.4899,38.4401]}}',
         api_key: "yCM9DKRltA4gTGovk2naSvodO5iUDBCT7FAJ3CF5"
       }
     });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -185,7 +185,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "astral-regex": {
@@ -1086,7 +1086,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -2119,6 +2119,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -2537,6 +2543,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "log-symbols": {
@@ -3055,6 +3067,35 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
+    "nock": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-mocks-http": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.10.1.tgz",
@@ -3359,6 +3400,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {
@@ -4140,7 +4187,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-fest": {

--- a/app/package.json
+++ b/app/package.json
@@ -39,6 +39,7 @@
     "jshint": "2.12.0",
     "lint-staged": "10.5.4",
     "mocha": "8.3.1",
+    "nock": "13.0.11",
     "node-mocks-http": "1.10.1",
     "nodemon": "2.0.7",
     "prettier": "2.2.1"


### PR DESCRIPTION
## Related Issues:
* Closes #29

## Main Changes:
* Updated the `Climate information not available for location to calculate rFactor test` unit test to intercept and mock the Colorado request/response.
  * Note: The diff is fairly messy, because I had to move the tests that the `Climate information not available for location to calculate rFactor test` test to the end to get all tests to pass. The problem is the `nock` interceptor will keep intercepting the Colorado service for tests that happen after `nock` is used.
* Added the `Error retreiving county URL` test to verify the correct action happens when the Colorado web service is down.

## Steps To Test:
1. Run `npm run test`
2. Verify all of the tests pass
