### PR TITLE
bugfix/113_calculations-for-leap-years

### DIFF
--- a/app/app/server/controllers/rfactor.js
+++ b/app/app/server/controllers/rfactor.js
@@ -249,14 +249,13 @@ function calculateRFactor(metadataObj, EI_DAILY_AMOUNT, start_date, end_date) {
     } else {
       var startDayOfYear = getDayOfYear(start_date);
       var endDayOfYear = getDayOfYear(end_date);
-      let dailyEIdata = dailyEIdataNormal;
 
       if (endDayOfYear > startDayOfYear) {
         log.debug('Project is contained within a year');
 
         // determine whether or not the leap year data is needed for the start year
+        let dailyEIdata = dailyEIdataNormal;
         if(isStartLeapYear || isEndLeapYear) dailyEIdata = dailyEIdataLeapYear;
-        else dailyEIdata = dailyEIdataNormal;
 
         // subtract 1 from startDayOfYear because index on dailyEIdata starts with 0
         for (let p = startDayOfYear - 1; p < endDayOfYear; p++) {
@@ -266,8 +265,8 @@ function calculateRFactor(metadataObj, EI_DAILY_AMOUNT, start_date, end_date) {
         log.debug('Project crosses end of year');
 
         // determine whether or not the leap year data is needed for the start year
+        let dailyEIdata = dailyEIdataNormal;
         if(isStartLeapYear) dailyEIdata = dailyEIdataLeapYear;
-        else dailyEIdata = dailyEIdataNormal;
 
         // dayCounter variable ensures all days of project span are counted, even if a leap day is included
         var dayCounter = 0;

--- a/app/app/server/controllers/rfactor.js
+++ b/app/app/server/controllers/rfactor.js
@@ -219,10 +219,9 @@ function calculateRFactor(metadataObj, EI_DAILY_AMOUNT, start_date, end_date) {
       return;
     }
 
-    var dailyEIdataNormal = EI_DAILY_AMOUNT.replace(/\n/g, ' ').split(' ');
-    var dailyEIdataLeapYear = buildLeapYearData(dailyEIdataNormal);
-    var dailyEIdata = dailyEIdataNormal;
-    var rfactor = 0;
+    const dailyEIdataNormal = EI_DAILY_AMOUNT.replace(/\n/g, ' ').split(' ');
+    const dailyEIdataLeapYear = buildLeapYearData(dailyEIdataNormal);
+    let rfactor = 0;
 
     const isStartLeapYear = isLeapYear(start_date);
     const isEndLeapYear = isLeapYear(end_date);
@@ -250,6 +249,7 @@ function calculateRFactor(metadataObj, EI_DAILY_AMOUNT, start_date, end_date) {
     } else {
       var startDayOfYear = getDayOfYear(start_date);
       var endDayOfYear = getDayOfYear(end_date);
+      let dailyEIdata = dailyEIdataNormal;
 
       if (endDayOfYear > startDayOfYear) {
         log.debug('Project is contained within a year');


### PR DESCRIPTION
## Related Issues:
* #113 

## Main Changes:
* Fixed a bug where UNKNOWN would be returned if the user selected 12/31 for a leap year.

## Steps To Test:
1. Navigate to http://localhost:9090/
2. Select 08/02/2024 as the start date
3. Select 12/31/2024 as the end date
4. Search for DC
5. Click Calculate R Factor
6. Verify that a value is being displayed in R Factor that is not `Unknown`
7. Perform the same test as above using a non leap year (i.e., 2023)

