### PR TITLE
Bugfix/relative routes

### DIFF
--- a/app/app/public/404.html
+++ b/app/app/public/404.html
@@ -8,7 +8,7 @@
     <meta name="HandheldFriendly" content="true" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rainfall Erosivity Factor Calculator | US EPA | US EPA</title>
-
+    <base href="/" />
     <link rel="canonical" href="https://lew.epa.gov/400.html" />
     <link rel="shortlink" href="https://lew.epa.gov/400.html" />
     <meta

--- a/app/app/public/500.html
+++ b/app/app/public/500.html
@@ -8,7 +8,7 @@
     <meta name="HandheldFriendly" content="true" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rainfall Erosivity Factor Calculator | US EPA | US EPA</title>
-
+    <base href="/" />
     <link rel="canonical" href="https://lew.epa.gov/500.html" />
     <link rel="shortlink" href="https://lew.epa.gov/500.html" />
     <meta


### PR DESCRIPTION
## Main Changes:
* Explicitly set the base URL to use for relative paths on the 404 & 500 pages, so that nested page URLs can still find the necessary resources.

## Steps To Test:
1. Go to http://localhost:9091/you/can%27t/see/me. Confirm the 404 page is shown and the EPA template renders correctly.
2. Go to http://localhost:9091/404.html. Confirm the 404 page is shown and the EPA template renders correctly.
3. Go to http://localhost:9091/500.html. Confirm the 500 page is shown and the EPA template renders correctly.